### PR TITLE
When queue is ended, it doesn't destory player

### DIFF
--- a/dist/lib/CosmiSocket.js
+++ b/dist/lib/CosmiSocket.js
@@ -137,7 +137,6 @@ class CosmiSocket extends ws_1.default {
             player.queue.current = null;
             player.queue.clear();
             this.manager.emit("queueEnd", player);
-            player.destroy();
         }
     }
     /** Emits when a track errors */

--- a/src/lib/CosmiSocket.ts
+++ b/src/lib/CosmiSocket.ts
@@ -178,9 +178,7 @@ export class CosmiSocket extends WebSocket {
             player.paused = false;
             player.queue.current = null;
             player.queue.clear();
-
             this.manager.emit("queueEnd", player);
-            player.destroy();
         }
     }
 


### PR DESCRIPTION
To prevent a bot from leaving a voice channel when the queue is end, users can choose to add a destroy function in the relevant event. This makes it destroy  (optional)
